### PR TITLE
Streamline layout and add construction banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -34,13 +34,12 @@
   </script>
 </head>
 <body>
+  <div class="site-notice">🚧 This website is under construction — September 2025</div>
   <header class="site-header" id="top">
     <div class="container">
       <a href="#top" class="logo" aria-label="41 Labs home">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24" class="logo-mark" aria-hidden="true">
-          <text x="0" y="18" font-family="Inter, system-ui, sans-serif" font-size="18" fill="#E9EDF1">41</text>
-          <circle cx="37" cy="12" r="3" fill="#F4A300"></circle>
-          <text x="46" y="18" font-family="Inter, system-ui, sans-serif" font-size="18" fill="#E9EDF1">Labs</text>
+          <text x="0" y="18" font-family="Inter, system-ui, sans-serif" font-size="18" fill="#E9EDF1">41 Labs</text>
         </svg>
       </a>
       <nav class="nav" aria-label="Primary">
@@ -52,8 +51,6 @@
           <li><a href="#about">About</a></li>
           <li><a href="#investors">Investors</a></li>
           <li><a href="#contact">Contact</a></li>
-          <li><button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">🌓</button></li>
-          <h1> Website Currently under construction....</h1>
         </ul>
       </nav>
     </div>
@@ -62,10 +59,8 @@
   <main>
     <section id="hero" class="hero" tabindex="-1">
       <div class="container">
-        <h1>Engineering nature-inspired automation. </h1>
-         <h1> 41 Labs transforms applied research into sustainable, human‑centered products across agtech, petcare automation, and assistive kitchen tech.</h1>
-        
-        <p class="tagline">We turn R&amp;D into sustainable, human‑centered products.</p>
+        <h1>Engineering nature-inspired automation.</h1>
+        <p class="tagline">41 Labs transforms applied research into sustainable, human-centered products across agtech, petcare automation, and assistive kitchen tech.</p>
         <div class="cta-group">
           <a class="btn primary" href="#contact">Get in touch</a>
           <a class="btn secondary" href="#investors">Investor info</a>
@@ -131,36 +126,7 @@
       <div class="container">
         <h2>Contact</h2>
         <p>Interested in collaborating or running a pilot? Let's talk.</p>
-        <p>Email: <a href="mailto:hello@41-labs.com">hello@41-labs.com</a></p>
-        <form id="contact-form" action="https://formspree.io/f/your-id" method="POST" novalidate>
-          <label>
-            Name
-            <input type="text" name="name" required>
-          </label>
-          <label>
-            Email
-            <input type="email" name="email" required>
-          </label>
-          <label>
-            Company (optional)
-            <input type="text" name="company">
-          </label>
-          <label>
-            Interest
-            <select name="interest">
-              <option value="General">General</option>
-              <option value="Partnership">Partnership</option>
-              <option value="Investor">Investor</option>
-              <option value="Press">Press</option>
-            </select>
-          </label>
-          <label>
-            Message
-            <textarea name="message" rows="4" required></textarea>
-          </label>
-          <button type="submit" class="btn primary">Send message</button>
-          <p id="form-status" role="status" aria-live="polite"></p>
-        </form>
+        <p>Email us at <a href="mailto:hello@41-labs.com">hello@41-labs.com</a></p>
       </div>
     </section>
   </main>

--- a/script.js
+++ b/script.js
@@ -1,24 +1,7 @@
 // 41 Labs scripts
 (function(){
-  const root = document.documentElement;
-  const themeToggle = document.getElementById('theme-toggle');
   const navToggle = document.querySelector('.nav-toggle');
   const navMenu = document.getElementById('nav-menu');
-  const contactForm = document.getElementById('contact-form');
-  const formStatus = document.getElementById('form-status');
-
-  // Theme handling
-  function setTheme(mode){
-    root.setAttribute('data-theme', mode);
-    localStorage.setItem('theme', mode);
-  }
-  const savedTheme = localStorage.getItem('theme');
-  const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
-  setTheme(savedTheme || (prefersLight ? 'light' : 'dark'));
-  themeToggle.addEventListener('click', () => {
-    const current = root.getAttribute('data-theme');
-    setTheme(current === 'dark' ? 'light' : 'dark');
-  });
 
   // Mobile nav
   navToggle.addEventListener('click', () => {
@@ -58,34 +41,6 @@
         }
       }
     });
-  });
-
-  // Contact form
-  contactForm.addEventListener('submit', async e => {
-    e.preventDefault();
-    formStatus.textContent = '';
-    if(!contactForm.reportValidity()) return;
-    const endpoint = contactForm.getAttribute('action');
-    if(endpoint.includes('your-id')){
-      formStatus.textContent = 'Form endpoint not configured. Please email us.';
-      formStatus.style.color = '#F4A300';
-      return;
-    }
-    try {
-      const res = await fetch(endpoint, {
-        method: 'POST',
-        body: new FormData(contactForm),
-        headers: { 'Accept':'application/json' }
-      });
-      if(res.ok){
-        formStatus.textContent = 'Thanks! We will be in touch.';
-        contactForm.reset();
-      } else {
-        formStatus.textContent = 'Submission failed. Please email us.';
-      }
-    } catch(err){
-      formStatus.textContent = 'Network error. Please try again later.';
-    }
   });
 
   // Fade-in observer

--- a/styles.css
+++ b/styles.css
@@ -11,13 +11,6 @@
   --transition: 0.3s ease;
 }
 
-[data-theme="light"] {
-  --color-bg: #f5f6f8;
-  --color-surface: #ffffff;
-  --color-text: #111319;
-  --color-link: #0055ff;
-}
-
 /* ====== Base ====== */
 html {
   scroll-behavior: smooth;
@@ -25,7 +18,7 @@ html {
 
 body {
   margin: 0;
-  font-family: system-ui, sans-serif;
+  font-family: 'Inter', system-ui, sans-serif;
   background: var(--color-bg);
   color: var(--color-text);
   line-height: 1.6;
@@ -70,7 +63,7 @@ p, li {font-size: 1rem;}
   gap: var(--spacing);
 }
 .nav-menu a {color: var(--color-text); text-decoration: none;}
-.nav-menu a:hover, .nav-menu a:focus {color: var(--color-link);} 
+.nav-menu a:hover, .nav-menu a:focus {color: var(--color-link);}
 
 .nav-toggle {
   background: none;
@@ -91,8 +84,15 @@ p, li {font-size: 1rem;}
   .nav-menu.open {max-height:15rem;}
 }
 
-.theme-toggle {background:none; border:none; color:var(--color-text); font-size:1.2rem; cursor:pointer;}
-.theme-toggle:focus {outline: 2px solid var(--color-link);}
+
+/* Site notice */
+.site-notice {
+  background: var(--color-accent);
+  color: #111319;
+  text-align: center;
+  padding: 0.5rem;
+  font-weight: 600;
+}
 
 /* ====== Hero ====== */
 .hero {
@@ -121,7 +121,8 @@ p, li {font-size: 1rem;}
 /* ====== Sections ====== */
 .section {padding:4rem 0;}
 .card-grid {display:grid; gap:1.5rem; grid-template-columns:repeat(auto-fit,minmax(15rem,1fr));}
-.card {background:var(--color-surface); padding:1.5rem; border-radius:var(--radius); box-shadow:0 0 0 1px rgba(0,0,0,0.2);}
+.card {background:var(--color-surface); padding:1.5rem; border-radius:var(--radius); box-shadow:0 0 0 1px rgba(0,0,0,0.2); transition:transform var(--transition), box-shadow var(--transition);}
+.card:hover, .card:focus-within {transform:translateY(-4px); box-shadow:0 4px 10px rgba(0,0,0,0.3);}
 .card-icon {width:40px; height:40px;}
 
 .pillars {display:grid; grid-template-columns:repeat(auto-fit,minmax(10rem,1fr)); gap:0.5rem; list-style:none; padding:0;}
@@ -129,11 +130,6 @@ p, li {font-size: 1rem;}
 
 /* ====== Investors ====== */
 .investors ul {list-style:disc; padding-left:1.5rem;}
-
-/* ====== Contact ====== */
-form {display:grid; gap:1rem; max-width:35rem;}
-input, select, textarea {width:100%; padding:0.5rem; border-radius:var(--radius); border:1px solid #444; background:var(--color-bg); color:var(--color-text);}
-input:focus, select:focus, textarea:focus {outline:2px solid var(--color-link);}
 
 /* ====== Footer ====== */
 .site-footer {background:var(--color-surface); text-align:center;}


### PR DESCRIPTION
## Summary
- Add top construction notice and simplify logo branding
- Remove theme toggle and contact form for a cleaner layout
- Polish styles with Inter font and animated cards, plus prominent contact email

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f46ede808324a32e4ad6901aa51a